### PR TITLE
fix: 알림 누락 및 디코딩 오류 수정

### DIFF
--- a/BookBuddy/Home/Domain/NotificationInformation.swift
+++ b/BookBuddy/Home/Domain/NotificationInformation.swift
@@ -11,5 +11,5 @@ struct NotificationInformation {
     let notificationID: Int
     let notificationContent: String
     let profileImage: Data?
-    let boardImage: Data
+    let boardImage: Data?
 }

--- a/BookBuddy/Member/Activity/ViewController/BoardDetailViewController.swift
+++ b/BookBuddy/Member/Activity/ViewController/BoardDetailViewController.swift
@@ -171,12 +171,12 @@ extension BoardDetailViewController {
                 case 0:
                     self?.homeViewModel.setBoardLikeInformation(boardLikeInformation) { result in
                         guard result else { return }
+                        self?.homeViewModel.sendLikeNotification(boardInformation.postID)
                         DispatchQueue.main.async {
                             self?.boardDetailView.likeButton.setImage(UIImage(systemName: "heart.fill"), for: .normal)
                             self?.boardDetailView.likeButton.tag = 1
                             self?.changeLikeCountLabelValue(label: label, deleteLike: false)
                         }
-                            
                     }
                 default: return
                 }

--- a/BookBuddy/Network/Notification/DTO/NotificationDTO.swift
+++ b/BookBuddy/Network/Notification/DTO/NotificationDTO.swift
@@ -11,10 +11,10 @@ struct NotificationDTO: Codable {
     let notificationID: Int
     let notificationContent: String
     let profileImage: Data?
-    let boardImage: Data
+    let boardImage: Data?
 
     enum CodingKeys: String, CodingKey {
-        case notificationID = "notificaitonID"
+        case notificationID
         case notificationContent
         case profileImage
         case boardImage

--- a/BookBuddy/Notification/NotificationCollectionViewCell.swift
+++ b/BookBuddy/Notification/NotificationCollectionViewCell.swift
@@ -88,13 +88,22 @@ final class NotificationCollectionViewCell: UICollectionViewCell, ReuseIdentifie
         if let boardImage = information.boardImage {
             boardImageView.image = UIImage(data: boardImage)
             boardImageView.isHidden = false
+            if let widthConstraint = boardImageView.constraints.first(where: { $0.firstAttribute == .width }) {
+                widthConstraint.constant = 60.0
+            }
         } else {
             boardImageView.image = nil
             boardImageView.isHidden = true
+            if let widthConstraint = boardImageView.constraints.first(where: { $0.firstAttribute == .width }) {
+                widthConstraint.constant = 0.0
+            }
         }
         notificationContentLabel.text = information.notificationContent
-        guard let profileImage = information.profileImage else { return }
-        profileImageView.image = UIImage(data: profileImage)
+        if let profileImage = information.profileImage {
+            profileImageView.image = UIImage(data: profileImage)
+        } else {
+            profileImageView.image = UIImage(systemName: "person")
+        }
     }
 }
 

--- a/BookBuddy/Notification/NotificationCollectionViewCell.swift
+++ b/BookBuddy/Notification/NotificationCollectionViewCell.swift
@@ -85,7 +85,13 @@ final class NotificationCollectionViewCell: UICollectionViewCell, ReuseIdentifie
     }
     
     func setNotificationInfo(_ information: NotificationInformation) {
-        boardImageView.image = UIImage(data: information.boardImage)
+        if let boardImage = information.boardImage {
+            boardImageView.image = UIImage(data: boardImage)
+            boardImageView.isHidden = false
+        } else {
+            boardImageView.image = nil
+            boardImageView.isHidden = true
+        }
         notificationContentLabel.text = information.notificationContent
         guard let profileImage = information.profileImage else { return }
         profileImageView.image = UIImage(data: profileImage)


### PR DESCRIPTION
## Summary
- `NotificationDTO`의 `notificaitonID` CodingKey 오타 수정 → 알림 목록 디코딩 실패 해소
- 다른 사용자 프로필 상세에서 좋아요 눌렀을 때 `sendLikeNotification` 호출이 누락돼 알림이 발송되지 않던 버그 수정
- 팔로우 알림은 `boardImage`가 없어 서버가 `null`을 반환하므로, `NotificationInformation` / `NotificationDTO`의 `boardImage`를 옵셔널로 변경하고 `NotificationCollectionViewCell`에서 nil 처리

## Test plan
- [ ] 홈 탭 게시물 좋아요 → 작성자에게 푸시 도착
- [ ] 다른 사용자 프로필 상세 진입 → 게시물 좋아요 → 작성자에게 푸시 도착
- [ ] 다른 사용자 게시물에 댓글 작성 → 작성자에게 푸시 도착
- [ ] 다른 사용자 팔로우 → 대상 사용자에게 푸시 도착, 알림 목록에 표시 (boardImage 영역은 숨김)
- [ ] 좋아요/댓글 알림 목록 화면이 정상 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)