### PR TITLE
feat: 글 작성 화면 디자인 개편

### DIFF
--- a/BookBuddy/BoardWrite/View/BoardWriteView.swift
+++ b/BookBuddy/BoardWrite/View/BoardWriteView.swift
@@ -7,125 +7,268 @@
 
 import UIKit
 
+final class DashedBorderView: UIView {
+    var isDashedBorderHidden: Bool = false {
+        didSet { dashedBorderLayer.isHidden = isDashedBorderHidden }
+    }
+
+    private let dashedBorderLayer: CAShapeLayer = {
+        let layer = CAShapeLayer()
+        layer.strokeColor = UIColor.systemGray3.cgColor
+        layer.fillColor = nil
+        layer.lineWidth = 1.0
+        layer.lineDashPattern = [6, 4]
+        return layer
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        layer.addSublayer(dashedBorderLayer)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        dashedBorderLayer.frame = bounds
+        dashedBorderLayer.path = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: layer.cornerRadius
+        ).cgPath
+    }
+}
+
 final class BoardWriteView: UIView {
     let imagePickerView: UIImagePickerController = {
         let imagePickerView = UIImagePickerController()
         return imagePickerView
     }()
-    
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.keyboardDismissMode = .interactive
+        scrollView.alwaysBounceVertical = true
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+
+    private let contentStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 20.0
+        stackView.alignment = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    let imageCardView: DashedBorderView = {
+        let view = DashedBorderView()
+        view.backgroundColor = .secondarySystemBackground
+        view.layer.cornerRadius = 14.0
+        view.layer.masksToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isUserInteractionEnabled = true
+        return view
+    }()
+
+    private let imagePlaceholderStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = 6.0
+        stackView.isUserInteractionEnabled = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    private let cameraIconImageView: UIImageView = {
+        let imageView = UIImageView()
+        let config = UIImage.SymbolConfiguration(pointSize: 32.0, weight: .regular)
+        imageView.image = UIImage(systemName: "camera.fill", withConfiguration: config)
+        imageView.tintColor = .tertiaryLabel
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let imagePlaceholderTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "사진을 추가하세요"
+        label.textColor = .label
+        label.font = .systemFont(ofSize: 15.0, weight: .semibold)
+        return label
+    }()
+
+    private let imagePlaceholderSubtitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "탭하여 선택"
+        label.textColor = .secondaryLabel
+        label.font = .systemFont(ofSize: 12.0, weight: .regular)
+        return label
+    }()
+
+    let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.masksToBounds = true
+        imageView.isHidden = true
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let titleSectionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "제목"
+        label.textColor = .secondaryLabel
+        label.font = .systemFont(ofSize: 13.0, weight: .semibold)
+        return label
+    }()
+
     let titleTextField: UITextField = {
         let textField = UITextField()
-        textField.placeholder = "글의 제목을 입력하세요."
-        textField.font = .systemFont(ofSize: 16.0, weight: .bold)
+        textField.placeholder = "글의 제목을 입력하세요"
+        textField.font = .systemFont(ofSize: 16.0, weight: .semibold)
         textField.textColor = .label
-        textField.textAlignment = .left
+        textField.backgroundColor = .secondarySystemBackground
+        textField.layer.cornerRadius = 10.0
         textField.translatesAutoresizingMaskIntoConstraints = false
+        let leftPadding = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 0))
+        textField.leftView = leftPadding
+        textField.leftViewMode = .always
+        let rightPadding = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 0))
+        textField.rightView = rightPadding
+        textField.rightViewMode = .always
         return textField
     }()
-    
-    private let titleLineView: LineView = {
-        let lineView = LineView()
-        lineView.translatesAutoresizingMaskIntoConstraints = false
-        return lineView
+
+    private let contentSectionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "내용"
+        label.textColor = .secondaryLabel
+        label.font = .systemFont(ofSize: 13.0, weight: .semibold)
+        return label
     }()
-    
+
+    let contentTextView: UITextView = {
+        let textView = UITextView()
+        textView.font = .systemFont(ofSize: 15.0, weight: .regular)
+        textView.textColor = .label
+        textView.backgroundColor = .secondarySystemBackground
+        textView.layer.cornerRadius = 10.0
+        textView.textContainerInset = UIEdgeInsets(top: 12, left: 8, bottom: 12, right: 8)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        return textView
+    }()
+
+    let contentPlaceholderLabel: UILabel = {
+        let label = UILabel()
+        label.text = "어떤 책을 읽으셨나요?"
+        label.textColor = .tertiaryLabel
+        label.font = .systemFont(ofSize: 15.0, weight: .regular)
+        label.isUserInteractionEnabled = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
     let uploadButton: AnimationButton = {
         let button = AnimationButton()
         button.setTitle("업로드", for: .normal)
         button.setTitleColor(.systemGreen, for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 15.0, weight: .light)
+        button.titleLabel?.font = .systemFont(ofSize: 15.0, weight: .semibold)
         return button
     }()
-    
-    private let descriptionLabel: UILabel = {
-        let label = UILabel()
-        label.text = "게시글을 대표할 사진을 선택해 보세요."
-        label.textColor = .lightGray
-        label.font = .systemFont(ofSize: 13.0, weight: .light)
-        label.textAlignment = .center
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    let imageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.backgroundColor = .systemBackground
-        imageView.image = UIImage(systemName: "photo.circle")
-        imageView.tintColor = .label
-        return imageView
-    }()
-    
-    private let imageLineView: LineView = {
-        let lineView = LineView()
-        lineView.translatesAutoresizingMaskIntoConstraints = false
-        return lineView
-    }()
-    
-    let contentTextView: UITextView = {
-        let textView = UITextView()
-        textView.font = .systemFont(ofSize: 14.0, weight: .light)
-        textView.textAlignment = .left
-        textView.layer.borderColor = UIColor.lightGray.cgColor
-        textView.layer.borderWidth = 0.5
-        textView.layer.cornerRadius = 5.0
-        textView.translatesAutoresizingMaskIntoConstraints = false
-        return textView
-    }()
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
+        backgroundColor = .systemBackground
         addSubViews()
         setLayoutConstraints()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func setSelectedImage(_ image: UIImage) {
+        imageView.image = image
+        imageView.isHidden = false
+        imagePlaceholderStackView.isHidden = true
+        imageCardView.isDashedBorderHidden = true
+    }
+
+    func resetSelectedImage() {
+        imageView.image = nil
+        imageView.isHidden = true
+        imagePlaceholderStackView.isHidden = false
+        imageCardView.isDashedBorderHidden = false
+    }
+
+    func updateContentPlaceholderVisibility() {
+        contentPlaceholderLabel.isHidden = !contentTextView.text.isEmpty
     }
 }
 
 extension BoardWriteView {
     private func addSubViews() {
-        [
-            titleTextField,
-            titleLineView,
-            descriptionLabel,
-            imageView,
-            imageLineView,
-            contentTextView
-        ].forEach { self.addSubview($0) }
+        addSubview(scrollView)
+        scrollView.addSubview(contentStackView)
+
+        imagePlaceholderStackView.addArrangedSubview(cameraIconImageView)
+        imagePlaceholderStackView.addArrangedSubview(imagePlaceholderTitleLabel)
+        imagePlaceholderStackView.addArrangedSubview(imagePlaceholderSubtitleLabel)
+        imageCardView.addSubview(imageView)
+        imageCardView.addSubview(imagePlaceholderStackView)
+
+        let titleContainer = UIStackView(arrangedSubviews: [titleSectionLabel, titleTextField])
+        titleContainer.axis = .vertical
+        titleContainer.spacing = 8.0
+
+        let contentContainer = UIStackView(arrangedSubviews: [contentSectionLabel, contentTextView])
+        contentContainer.axis = .vertical
+        contentContainer.spacing = 8.0
+
+        contentStackView.addArrangedSubview(imageCardView)
+        contentStackView.addArrangedSubview(titleContainer)
+        contentStackView.addArrangedSubview(contentContainer)
+
+        contentTextView.addSubview(contentPlaceholderLabel)
     }
-    
+
     private func setLayoutConstraints() {
+        let frameGuide = scrollView.frameLayoutGuide
+        let contentGuide = scrollView.contentLayoutGuide
+
         NSLayoutConstraint.activate([
-            titleTextField.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: 8.0),
-            titleTextField.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: 8.0),
-            titleTextField.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: -8.0),
-            titleTextField.heightAnchor.constraint(equalToConstant: 40.0),
-            
-            titleLineView.topAnchor.constraint(equalTo: titleTextField.bottomAnchor, constant: 4.0),
-            titleLineView.leadingAnchor.constraint(equalTo: titleTextField.leadingAnchor),
-            titleLineView.trailingAnchor.constraint(equalTo: titleTextField.trailingAnchor),
-            titleLineView.heightAnchor.constraint(equalToConstant: 0.5),
-    
-            contentTextView.topAnchor.constraint(equalTo: titleLineView.bottomAnchor, constant: 4.0),
-            contentTextView.leadingAnchor.constraint(equalTo: titleTextField.leadingAnchor),
-            contentTextView.trailingAnchor.constraint(equalTo: titleTextField.trailingAnchor),
-            contentTextView.heightAnchor.constraint(equalToConstant: 280.0),
-            
-            imageLineView.topAnchor.constraint(equalTo: contentTextView.bottomAnchor, constant: 4.0),
-            imageLineView.leadingAnchor.constraint(equalTo: titleTextField.leadingAnchor),
-            imageLineView.trailingAnchor.constraint(equalTo: titleTextField.trailingAnchor),
-            imageLineView.heightAnchor.constraint(equalToConstant: 0.5),
-            
-            descriptionLabel.topAnchor.constraint(equalTo: imageLineView.bottomAnchor, constant: 4.0),
-            descriptionLabel.leadingAnchor.constraint(equalTo: titleTextField.leadingAnchor),
-            descriptionLabel.trailingAnchor.constraint(equalTo: titleTextField.trailingAnchor),
-            
-            imageView.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 4.0),
-            imageView.centerXAnchor.constraint(equalTo: self.safeAreaLayoutGuide.centerXAnchor),
-            imageView.heightAnchor.constraint(equalToConstant: 300.0),
-            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor)
+            scrollView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+
+            contentStackView.topAnchor.constraint(equalTo: contentGuide.topAnchor, constant: 20.0),
+            contentStackView.leadingAnchor.constraint(equalTo: contentGuide.leadingAnchor, constant: 16.0),
+            contentStackView.trailingAnchor.constraint(equalTo: contentGuide.trailingAnchor, constant: -16.0),
+            contentStackView.bottomAnchor.constraint(equalTo: contentGuide.bottomAnchor, constant: -20.0),
+            contentStackView.widthAnchor.constraint(equalTo: frameGuide.widthAnchor, constant: -32.0),
+
+            imageCardView.heightAnchor.constraint(equalTo: imageCardView.widthAnchor, multiplier: 0.66),
+
+            imagePlaceholderStackView.centerXAnchor.constraint(equalTo: imageCardView.centerXAnchor),
+            imagePlaceholderStackView.centerYAnchor.constraint(equalTo: imageCardView.centerYAnchor),
+
+            imageView.topAnchor.constraint(equalTo: imageCardView.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: imageCardView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: imageCardView.trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: imageCardView.bottomAnchor),
+
+            titleTextField.heightAnchor.constraint(equalToConstant: 48.0),
+
+            contentTextView.heightAnchor.constraint(greaterThanOrEqualToConstant: 240.0),
+
+            contentPlaceholderLabel.topAnchor.constraint(equalTo: contentTextView.topAnchor, constant: 12.0),
+            contentPlaceholderLabel.leadingAnchor.constraint(equalTo: contentTextView.leadingAnchor, constant: 13.0),
         ])
     }
 }

--- a/BookBuddy/BoardWrite/ViewController/BoardEditViewController.swift
+++ b/BookBuddy/BoardWrite/ViewController/BoardEditViewController.swift
@@ -69,7 +69,10 @@ extension BoardEditViewController {
         guard let boardEditInformation = boardEditViewModel.boardEditInformation else { return }
         boardEditView.titleTextField.text = boardEditInformation.contentTitle
         boardEditView.contentTextView.text = boardEditInformation.content
-        boardEditView.imageView.image = UIImage(data: boardEditInformation.boardImage)
+        boardEditView.updateContentPlaceholderVisibility()
+        if let image = UIImage(data: boardEditInformation.boardImage) {
+            boardEditView.setSelectedImage(image)
+        }
     }
     
     private func addEditingTapGesture() {
@@ -90,8 +93,7 @@ extension BoardEditViewController {
     
     private func imageUploadTapGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(imageViewTapGesture))
-        boardEditView.imageView.isUserInteractionEnabled = true
-        boardEditView.imageView.addGestureRecognizer(tapGesture)
+        boardEditView.imageCardView.addGestureRecognizer(tapGesture)
     }
     
     @objc private func imageViewTapGesture() {
@@ -179,21 +181,25 @@ extension BoardEditViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         self.endEditingGesture?.isEnabled = true
     }
-    
+
     func textViewDidEndEditing(_ textView: UITextView) {
         self.endEditingGesture?.isEnabled = false
     }
-    
+
     func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
         textView.resignFirstResponder()
         return true
+    }
+
+    func textViewDidChange(_ textView: UITextView) {
+        boardEditView.updateContentPlaceholderVisibility()
     }
 }
 
 extension BoardEditViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         guard let editedImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage else { return }
-        boardEditView.imageView.image = editedImage
+        boardEditView.setSelectedImage(editedImage)
         dismiss(animated: true)
     }
 }

--- a/BookBuddy/BoardWrite/ViewController/BoardWriteViewController.swift
+++ b/BookBuddy/BoardWrite/ViewController/BoardWriteViewController.swift
@@ -76,8 +76,7 @@ extension BoardWriteViewController {
     
     private func imageUploadTapGesture() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(imageViewTapGesture))
-        boardWriteView.imageView.isUserInteractionEnabled = true
-        boardWriteView.imageView.addGestureRecognizer(tapGesture)
+        boardWriteView.imageCardView.addGestureRecognizer(tapGesture)
     }
     
     @objc private func imageViewTapGesture() {
@@ -104,7 +103,8 @@ extension BoardWriteViewController {
         let doneAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
             self?.boardWriteView.titleTextField.text = ""
             self?.boardWriteView.contentTextView.text = ""
-            self?.boardWriteView.imageView.image = UIImage(systemName: "photo.circle")
+            self?.boardWriteView.updateContentPlaceholderVisibility()
+            self?.boardWriteView.resetSelectedImage()
             UserDefaults.standard.removeObject(forKey: UserDefaultsForkey.boardImage.rawValue)
         }
         alertController.addAction(doneAction)
@@ -189,14 +189,18 @@ extension BoardWriteViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         self.endEditingGesture?.isEnabled = true
     }
-    
+
     func textViewDidEndEditing(_ textView: UITextView) {
         self.endEditingGesture?.isEnabled = false
     }
-    
+
     func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
         textView.resignFirstResponder()
         return true
+    }
+
+    func textViewDidChange(_ textView: UITextView) {
+        boardWriteView.updateContentPlaceholderVisibility()
     }
 }
 
@@ -204,7 +208,7 @@ extension BoardWriteViewController: UIImagePickerControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         guard let editedImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage,
               let imageData = editedImage.pngData() else { return }
-        boardWriteView.imageView.image = editedImage
+        boardWriteView.setSelectedImage(editedImage)
         UserDefaults.standard.setValue(imageData, forKey: UserDefaultsForkey.boardImage.rawValue)
         dismiss(animated: true)
     }


### PR DESCRIPTION
## Summary
- 상단 이미지 선택 카드(점선 테두리 + 카메라 아이콘 + 안내 텍스트)로 사진 추가 발견성 개선
- 섹션 라벨(`제목`/`내용`)과 둥근 모서리 입력 배경으로 시각적 위계 정리
- 본문 `UITextView`에 placeholder 도입 (입력 시 자동 숨김)
- `UIScrollView` 래핑으로 키보드가 올라와도 콘텐츠 잘리지 않도록 개선
- `BoardEditViewController`도 동일한 View를 공유하므로 함께 정렬
- 점선 테두리는 `DashedBorderView` 헬퍼 클래스로 추출하되, 별도 파일 분리 시 Xcode 프로젝트 등록 작업이 필요하므로 `BoardWriteView.swift`에 함께 둠

## Test plan
- [ ] 글 작성 탭 진입 → 이미지 카드의 점선 테두리/카메라 아이콘/안내 문구가 보이는지 확인
- [ ] 이미지 카드 탭 → 액션시트 → 앨범에서 사진 선택 → 카드가 선택한 이미지로 교체되는지 확인
- [ ] 제목/내용 입력 시 배경 박스 라운드 처리, placeholder가 자연스럽게 사라지는지 확인
- [ ] 업로드 성공 후 입력값과 이미지, placeholder가 모두 초기 상태로 돌아가는지 확인
- [ ] 본인 게시물 편집(`BoardEditViewController`) 진입 시 기존 이미지/제목/본문이 정상적으로 채워지고, placeholder가 숨겨지는지 확인
- [ ] 키보드 노출 상태에서 컨텐츠가 스크롤로 가려지지 않는지 확인
- [ ] 다크 모드에서도 색상 위계가 자연스러운지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)